### PR TITLE
Refactor msbuild files

### DIFF
--- a/ClientUpdater/ClientUpdater.csproj
+++ b/ClientUpdater/ClientUpdater.csproj
@@ -1,22 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net48</TargetFrameworks>
     <Title>CnCNet.ClientUpdater</Title>
     <Description>CnCNet Client Updater Library</Description>
     <Company>CnCNet</Company>
     <Product>CnCNet.ClientUpdater</Product>
     <Copyright>Copyright © CnCNet 2022-2024</Copyright>
     <Trademark></Trademark>
-    <AssemblyName>ClientUpdater</AssemblyName>
-    <RootNamespace>ClientUpdater</RootNamespace>
-    <ComVisible>false</ComVisible>
-    <CLSCompliant>false</CLSCompliant>
-    <AnalysisLevel>latest-all</AnalysisLevel>
-    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
-    <Platforms>AnyCPU</Platforms>
-    <GenerateDocumentationFile>True</GenerateDocumentationFile>
-    <ComVisible>false</ComVisible>
-    <CLSCompliant>false</CLSCompliant>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
@@ -27,15 +16,6 @@
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <PackageLicenseExpression></PackageLicenseExpression>
     <EnablePackageValidation>true</EnablePackageValidation>
-    <AnalysisMode Condition="'$(Configuration)' == 'Debug'">All</AnalysisMode>
-    <EnforceCodeStyleInBuild Condition="'$(Configuration)' == 'Debug'">true</EnforceCodeStyleInBuild>
-    <AnalysisMode Condition="'$(Configuration)' != 'Debug'">Recommended</AnalysisMode>
-    <AnalysisModeDocumentation Condition="'$(Configuration)' != 'Debug'">None</AnalysisModeDocumentation>
-    <AnalysisModeNaming Condition="'$(Configuration)' != 'Debug'">None</AnalysisModeNaming>
-    <AnalysisModeStyle Condition="'$(Configuration)' != 'Debug'">None</AnalysisModeStyle>
-    <LangVersion>12.0</LangVersion>
-    <Nullable>disable</Nullable>
-    <ImplicitUsings>disable</ImplicitUsings>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNet.WebApi.Client" />

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,6 +3,9 @@
     <LangVersion>12.0</LangVersion>
     <ComVisible>false</ComVisible>
     <CLSCompliant>false</CLSCompliant>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <!-- TODO: We should enable it to eliminate the null hazard during development. -->
+    <Nullable>disable</Nullable>
 
     <Title>CnCNet Client</Title>
     <Company>CnCNet</Company>
@@ -39,7 +42,6 @@
   <PropertyGroup Condition="'$(MSBuildProjectName)' == 'ClientCore' Or '$(MSBuildProjectName)' == 'ClientGUI' Or '$(MSBuildProjectName)' == 'DTAConfig' Or '$(MSBuildProjectName)' == 'DXMainClient'">
     <TargetFrameworks Condition="$(Engine.Contains(Windows))">net48;net8.0-windows</TargetFrameworks>
     <TargetFrameworks Condition="!$(Engine.Contains(Windows))">net8.0</TargetFrameworks>
-    <TargetFrameworks Condition="'$(MSBuildProjectName)' == 'TranslationNotifierGenerator'">netstandard2.0</TargetFrameworks>
 
     <Platforms>AnyCPU;x64;x86;ARM64</Platforms>
     <Platforms Condition="'$(MSBuildProjectName)' == 'TranslationNotifierGenerator'">AnyCPU</Platforms>
@@ -49,10 +51,16 @@
     <!-- WinForms Auto Configure -->
     <UseWindowsForms Condition="$(Engine.Contains(Windows))">true</UseWindowsForms>
   </PropertyGroup>
-    
+
   <PropertyGroup Condition="'$(MSBuildProjectName)' == 'TranslationNotifierGenerator'">
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <Platforms>AnyCPU</Platforms>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(MSBuildProjectName)' == 'ClientUpdater' OR '$(MSBuildProjectName)' == 'SecondStageUpdater'">
+    <TargetFrameworks>net8.0;net48</TargetFrameworks>
+    <Platforms>AnyCPU</Platforms>
+    <GenerateDocumentationFile>True</GenerateDocumentationFile>
   </PropertyGroup>
 
   <!-- For Constants -->

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -85,9 +85,10 @@
   <PropertyGroup>
     <ClientConfiguration Condition="$(Configuration.Contains(Debug))">Debug</ClientConfiguration>
     <ClientConfiguration Condition="$(Configuration.Contains(Release))">Release</ClientConfiguration>
-    <OutputPath Condition="'$(ClientConfiguration)' != ''">$(BaseOutputPath)bin\$(ClientConfiguration)\$(Game)\$(Engine)\</OutputPath>
-    <IntermediateOutputPath Condition="'$(ClientConfiguration)' != ''">$(BaseIntermediateOutputPath)obj\$(ClientConfiguration)\$(Game)\$(Engine)\</IntermediateOutputPath>
-    <ArtifactsPivots>$(ClientConfiguration)\$(Game)\$(Engine)\$(TargetFramework)</ArtifactsPivots>
+    <OutputPathSuffix>$(ClientConfiguration)\$(Game)\$(Engine)\</OutputPathSuffix>
+    <OutputPath Condition="'$(ClientConfiguration)' != ''">$(BaseOutputPath)bin\$(OutputPathSuffix)</OutputPath>
+    <IntermediateOutputPath Condition="'$(ClientConfiguration)' != ''">$(BaseIntermediateOutputPath)obj\$(OutputPathSuffix)</IntermediateOutputPath>
+    <ArtifactsPivots>$(OutputPathSuffix)$(TargetFramework)</ArtifactsPivots>
   </PropertyGroup>
 
   <!-- Support WindowsXNA 32bit debugging in VS -->

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -71,13 +71,13 @@
 
   <Target Name="CopyResources" AfterTargets="Build" Condition="$(DefineConstants.Contains('DEBUG'))">
     <ItemGroup>
-      <ExampleClientResources Include="$(SolutionDir)\DXMainClient\Resources\DTA\**\*.*" />
-      <ExampleClientMaps Include="$(SolutionDir)\DXMainClient\Resources\Maps\**\*.*" />
-      <ExampleClientIni Include="$(SolutionDir)\DXMainClient\Resources\INI\**\*.*" />
-      <ExampleClientMix Include="$(SolutionDir)\DXMainClient\Resources\MIX\**\*.*" />
-      <ExampleClientSettings Include="$(SolutionDir)\DXMainClient\Resources\Settings.ini" />
-      <ExampleClientLinuxRun Include="$(SolutionDir)\DXMainClient\Resources\run.sh" />
-      <ExampleClientDefinitions Include="$(SolutionDir)\DXMainClient\Resources\ClientDefinitions.ini" />
+      <ExampleClientResources Include="$(MSBuildThisFileDirectory)\DXMainClient\Resources\DTA\**\*.*" />
+      <ExampleClientMaps Include="$(MSBuildThisFileDirectory)\DXMainClient\Resources\Maps\**\*.*" />
+      <ExampleClientIni Include="$(MSBuildThisFileDirectory)\DXMainClient\Resources\INI\**\*.*" />
+      <ExampleClientMix Include="$(MSBuildThisFileDirectory)\DXMainClient\Resources\MIX\**\*.*" />
+      <ExampleClientSettings Include="$(MSBuildThisFileDirectory)\DXMainClient\Resources\Settings.ini" />
+      <ExampleClientLinuxRun Include="$(MSBuildThisFileDirectory)\DXMainClient\Resources\run.sh" />
+      <ExampleClientDefinitions Include="$(MSBuildThisFileDirectory)\DXMainClient\Resources\ClientDefinitions.ini" />
     </ItemGroup>
     <Copy Condition="! Exists('$(OutputPath)\Resources\ClientDefinitions.ini') " SourceFiles="@(ExampleClientResources)" DestinationFolder="$(OutputPath)\Resources\%(RecursiveDir)" />
     <Copy Condition="! Exists('$(OutputPath)\Resources\ClientDefinitions.ini') " SourceFiles="@(ExampleClientMaps)" DestinationFolder="$(OutputPath)\Maps\%(RecursiveDir)" />

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -88,6 +88,19 @@
     <Copy Condition="! Exists('$(OutputPath)\Resources\ClientDefinitions.ini') " SourceFiles="@(ExampleClientDefinitions)" DestinationFolder="$(OutputPath)\Resources" />
   </Target>
 
+  <Target Name="CopyUpdater" AfterTargets="Build" Condition="'$(MSBuildProjectName)' == 'SecondStageUpdater'">
+    <PropertyGroup>
+      <CNCNetUpdaterCopyTo>$(MSBuildThisFileDirectory)\DXMainClient\bin\$(OutputPathSuffix)</CNCNetUpdaterCopyTo>
+      <__CNCNetUpdaterTFM>$(TargetFramework)</__CNCNetUpdaterTFM>
+      <__CNCNetUpdaterTFM Condition="!$(TargetFramework.StartsWith('net4')) AND $(Engine.Contains(Windows))">$(TargetFramework)-windows</__CNCNetUpdaterTFM>
+      <CNCNetUpdaterCopyTo>$(CNCNetUpdaterCopyTo)$(__CNCNetUpdaterTFM)\Resources\Updater</CNCNetUpdaterCopyTo>
+    </PropertyGroup>
+    <ItemGroup>
+      <CNCNetUpdaterOutputFile Include="$(OutputPath)\*.*" />
+    </ItemGroup>
+    <Copy SourceFiles="@(CNCNetUpdaterOutputFile)" DestinationFolder="$(CNCNetUpdaterCopyTo)" />
+  </Target>
+
   <!-- Allow a game specific build prop file to be imported, if available -->
   <Import Project="$(MSBuildThisFileDirectory)Directory.$(Game).targets" Condition="Exists('$(MSBuildThisFileDirectory)Directory.$(Game).targets')" />
 

--- a/SecondStageUpdater/SecondStageUpdater.csproj
+++ b/SecondStageUpdater/SecondStageUpdater.csproj
@@ -1,33 +1,17 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
+    <UseAppHost>false</UseAppHost>
+  </PropertyGroup>
+  <PropertyGroup>
     <Title>CnCNet.SecondStageUpdater</Title>
     <Description>CnCNet Client Second-Stage Updater</Description>
     <Company>CnCNet</Company>
     <Product>CnCNet.SecondStageUpdater</Product>
     <Copyright>Copyright © CnCNet 2022-2024</Copyright>
     <Trademark></Trademark>
-    <AssemblyName>SecondStageUpdater</AssemblyName>
-    <RootNamespace>SecondStageUpdater</RootNamespace>
-    <ComVisible>false</ComVisible>
-    <CLSCompliant>false</CLSCompliant>
-    <AnalysisLevel>latest-all</AnalysisLevel>
-    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
-    <Platforms>AnyCPU</Platforms>
-    <GenerateDocumentationFile>True</GenerateDocumentationFile>
-    <ComVisible>false</ComVisible>
-    <CLSCompliant>false</CLSCompliant>
-    <UseAppHost>false</UseAppHost>
-    <LangVersion>12.0</LangVersion>
-    <Nullable>disable</Nullable>
-    <ImplicitUsings>disable</ImplicitUsings>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Rampastring.Tools"/>
-    <PackageReference Include="Polyfill" Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="Rampastring.Tools" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
> [!note]
> 尽力避免使用 `$(SolutionDir)` 属性而是应该选择使用 `$(MSBuildThisFileDirectory)` 属性。
> 这样做的好处是可以使用 dotnet cli 来编译项目，而不是整个解决方案。